### PR TITLE
Update offsets.c to support iPod5,1 at iOS 9.1 (13B143)

### DIFF
--- a/src/lib/offsets.c
+++ b/src/lib/offsets.c
@@ -248,6 +248,7 @@ static addr_t reg_anchor(void)
             switch(version)
             {
                 case V_13F69:   return 0x800a744b;
+                case V_13B143:  return 0x800a7b93;
                 default:        THROW("Unsupported version");
             }
 #endif
@@ -282,6 +283,7 @@ static addr_t reg_vtab(void)
             switch(version)
             {
                 case V_13F69:   return 0x803ece94;
+                case V_13B143:  return 0x803eee50;
                 default:        THROW("Unsupported version");
             }
 #endif


### PR DESCRIPTION
I've found the required offsets for the iPod 5 at iOS 9.1.