### PR TITLE
Offsets for iPhone 6s N71AP, 13G34 (same as SE)

### DIFF
--- a/src/lib/offsets.c
+++ b/src/lib/offsets.c
@@ -230,6 +230,7 @@ static addr_t reg_anchor(void)
     switch(model)
     {
 #ifdef __LP64__
+        case M_N71AP:
         case M_N69AP:
             switch(version)
             {
@@ -264,6 +265,7 @@ static addr_t reg_vtab(void)
     switch(model)
     {
 #ifdef __LP64__
+        case M_N71AP:
         case M_N69AP:
             switch(version)
             {


### PR DESCRIPTION
cl0ver panic gave anchor 0xffffff801fd36000, PC 0xfffff801fcef1f0, slide 0x000000001b800000